### PR TITLE
Fix media event relationship annotation

### DIFF
--- a/backend/app/models/media.py
+++ b/backend/app/models/media.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from sqlalchemy import ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -7,15 +8,17 @@ from ..db import Base
 
 
 class Media(Base):
-	__tablename__ = "media"
+    __tablename__ = "media"
 
-	id: Mapped[int] = mapped_column(primary_key=True, index=True)
-	file_name: Mapped[str]
-	file_path: Mapped[str]
-	thumb_path: Mapped[str | None]
-	uploaded_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
-	owner_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
-	event_id: Mapped[int | None] = mapped_column(ForeignKey("events.id", ondelete="SET NULL"), default=None)
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    file_name: Mapped[str]
+    file_path: Mapped[str]
+    thumb_path: Mapped[str | None]
+    uploaded_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    owner_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    event_id: Mapped[int | None] = mapped_column(
+        ForeignKey("events.id", ondelete="SET NULL"), default=None
+    )
 
-	owner: Mapped["User"] = relationship(back_populates="media")
-	event: Mapped["Event" | None] = relationship(back_populates="media_items")
+    owner: Mapped["User"] = relationship(back_populates="media")
+    event: Mapped[Optional["Event"]] = relationship(back_populates="media_items")


### PR DESCRIPTION
## Summary
- import `Optional` in the Media model and reformat the class definition for consistent indentation
- annotate the `event` relationship with `Mapped[Optional["Event"]]` to avoid optional forward reference errors

## Testing
- `python - <<'PY'
from backend.app.models.media import Media
print('Imported Media', Media.__name__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68e1dd372ff0832b8933d9e05a5dcacd